### PR TITLE
Find JavaScript Tests

### DIFF
--- a/assets/scripts/datastores/partials/scripts.js
+++ b/assets/scripts/datastores/partials/scripts.js
@@ -1,5 +1,3 @@
 import displaySearchTip from './_search.js';
 
-document.addEventListener('DOMContentLoaded', () => {
-  displaySearchTip();
-});
+displaySearchTip();

--- a/assets/scripts/partials/scripts.js
+++ b/assets/scripts/partials/scripts.js
@@ -1,5 +1,3 @@
 import chooseAffiliation from './header/_choose-affiliation.js';
 
-document.addEventListener('DOMContentLoaded', () => {
-  chooseAffiliation();
-});
+chooseAffiliation();

--- a/assets/scripts/scripts.js
+++ b/assets/scripts/scripts.js
@@ -1,5 +1,3 @@
 import removeBodyClasses from './layout';
 
-document.addEventListener('DOMContentLoaded', () => {
-  removeBodyClasses();
-});
+removeBodyClasses();

--- a/test/find-specs.spec.js
+++ b/test/find-specs.spec.js
@@ -1,0 +1,27 @@
+import { expect } from 'chai';
+import fs from 'fs';
+
+const deepSearch = (path) => {
+  fs.readdirSync(path).forEach((listing) => {
+    const listingPath = `${path}/${listing}`;
+    // Keep searching until the current listing is not a directory
+    if (!listing.includes('.')) {
+      deepSearch(listingPath);
+    }
+    // Check if current listing is a JavaScript file
+    if (listing.endsWith('.js')) {
+      // Convert current listing path into matching spec path
+      let specPath = path.split('/');
+      specPath[0] = 'test';
+      specPath = `${specPath.join('/')}/${listing.slice(0, -3)}.spec.js`;
+      // Return test to see if the spec exists
+      it(`'${listingPath}' has a spec file ('${specPath}')`, function () {
+        expect(fs.existsSync(`${specPath}`)).to.be.true;
+      });
+    }
+  });
+};
+
+describe('checks if component files have associated specs', function () {
+  deepSearch('assets/scripts');
+});

--- a/test/find-specs.spec.js
+++ b/test/find-specs.spec.js
@@ -1,19 +1,18 @@
 import { existsSync, readdirSync } from 'fs';
-import { extname, join } from 'path';
 import { expect } from 'chai';
 
-const getJsFilesRecursively = (directory = 'assets/scripts') => {
+const getJavaScriptFiles = (directory = 'assets/scripts') => {
   let jsFiles = [];
-  // Read the directory contents
   const entries = readdirSync(directory, { withFileTypes: true });
 
   for (const entry of entries) {
-    const fullPath = join(directory, entry.name);
+    const { name } = entry;
+    const fullPath = [directory, name].join('/');
     if (entry.isDirectory()) {
       // If the entry is a directory, recursively search it
-      jsFiles = jsFiles.concat(getJsFilesRecursively(fullPath));
-    } else if (entry.isFile() && extname(entry.name) === '.js') {
-      // If the entry is a .js file, add it to the list
+      jsFiles = jsFiles.concat(getJavaScriptFiles(fullPath));
+    } else if (entry.isFile() && name !== 'scripts.js') {
+      // If the entry is a .js file that's not named `scripts.js`, add it to the list
       jsFiles.push(fullPath);
     }
   }
@@ -23,7 +22,7 @@ const getJsFilesRecursively = (directory = 'assets/scripts') => {
 
 describe('spec files exist', function () {
   it('should have a spec file for every JavaScript file', function () {
-    getJsFilesRecursively().forEach((filePath) => {
+    getJavaScriptFiles().forEach((filePath) => {
       const testFile = filePath.replace('assets/', 'test/').replace('.js', '.spec.js');
       expect(existsSync(testFile), `\`${filePath}\` should have a spec file located at: \`${testFile}\``).to.be.true;
     });

--- a/test/find-specs.spec.js
+++ b/test/find-specs.spec.js
@@ -1,27 +1,31 @@
+import { existsSync, readdirSync } from 'fs';
+import { extname, join } from 'path';
 import { expect } from 'chai';
-import fs from 'fs';
 
-const deepSearch = (path) => {
-  fs.readdirSync(path).forEach((listing) => {
-    const listingPath = `${path}/${listing}`;
-    // Keep searching until the current listing is not a directory
-    if (!listing.includes('.')) {
-      deepSearch(listingPath);
+const getJsFilesRecursively = (directory = 'assets/scripts') => {
+  let jsFiles = [];
+  // Read the directory contents
+  const entries = readdirSync(directory, { withFileTypes: true });
+
+  for (const entry of entries) {
+    const fullPath = join(directory, entry.name);
+    if (entry.isDirectory()) {
+      // If the entry is a directory, recursively search it
+      jsFiles = jsFiles.concat(getJsFilesRecursively(fullPath));
+    } else if (entry.isFile() && extname(entry.name) === '.js') {
+      // If the entry is a .js file, add it to the list
+      jsFiles.push(fullPath);
     }
-    // Check if current listing is a JavaScript file
-    if (listing.endsWith('.js')) {
-      // Convert current listing path into matching spec path
-      let specPath = path.split('/');
-      specPath[0] = 'test';
-      specPath = `${specPath.join('/')}/${listing.slice(0, -3)}.spec.js`;
-      // Return test to see if the spec exists
-      it(`'${listingPath}' has a spec file ('${specPath}')`, function () {
-        expect(fs.existsSync(`${specPath}`)).to.be.true;
-      });
-    }
-  });
+  }
+
+  return jsFiles;
 };
 
-describe('checks if component files have associated specs', function () {
-  deepSearch('assets/scripts');
+describe('spec files exist', function () {
+  it('should have a spec file for every JavaScript file', function () {
+    getJsFilesRecursively().forEach((filePath) => {
+      const testFile = filePath.replace('assets/', 'test/').replace('.js', '.spec.js');
+      expect(existsSync(testFile), `\`${filePath}\` should have a spec file located at: \`${testFile}\``).to.be.true;
+    });
+  });
 });


### PR DESCRIPTION
# Overview
This pull request adds a unit test that recursively searches `./assets/scripts` and checks if every `.js` file, with the exception of `scripts.js` files, has a spec file for it.

## `scripts.js` files
The files originally added the `DOMContentLoaded` event listener to the `document` to make sure all of the DOM was loaded before changes were made. This is unnecessary since the scripts are loaded at the very end of the DOM, all the DOM has been loaded by the time the scripts are read. All that leaves are the functions being imported, and invoking those functions. If a function was being invoked that wasn't imported, or a function was imported but not invoked, ESLint will throw an error and not build. Once the linting passes, the only possible testing remaining would be to see if the function works, which already exists in their original spec files. This is why `scripts.js` files are excluded from making sure they have unit tests.