### PR TITLE
Change to yabeda custom middleware

### DIFF
--- a/config.ru
+++ b/config.ru
@@ -1,4 +1,6 @@
 require "./app"
+require "./lib/structured_access_logging_middleware"
 
 use Metrics::Middleware
+use StructuredAccessLoggingMiddleware
 run Search::Application

--- a/lib/search/helpers.rb
+++ b/lib/search/helpers.rb
@@ -1,3 +1,4 @@
+require "yaml"
 module Search
   module ViewHelpers
     def link_to(body:, url:, classes: [], open_in_new: false, utm_source: "library-search", rest: nil)

--- a/lib/structured_access_logging_middleware.rb
+++ b/lib/structured_access_logging_middleware.rb
@@ -1,0 +1,57 @@
+require "semantic_logger"
+require "rack"
+
+# This is largely taken from Rack::CommonLogger. It assumes you are using
+# SemanticLogger for logs.
+class StructuredAccessLoggingMiddleware
+  attr_reader :app
+  include Rack
+
+  def initialize(app)
+    @app = app
+    @logger = SemanticLogger["access_log"]
+  end
+
+  # Common Log Format (2.5): https://httpd.apache.org/docs/trunk/logs.html#accesslog
+  #
+  # The actual format is slightly different than the above due to the
+  # inclusion of referer, user_agent, and elapsed time in seconds
+
+  # Log all requests in common_log format after a response has been
+  # returned.  Note that if the app raises an exception, the request
+  # will not be logged, so if exception handling middleware are used,
+  # they should be loaded after this middleware.  Additionally, because
+  # the logging happens after the request body has been fully sent, any
+  # exceptions raised during the sending of the response body will
+  # cause the request not to be logged.
+  def call(env)
+    began_at = Rack::Utils.clock_time
+    status, headers, body = response = @app.call(env)
+
+    response[2] = Rack::BodyProxy.new(body) { log(env, status, headers, began_at) }
+    response
+  end
+
+  private
+
+  # Log the request to the configured logger.
+  def log(env, status, response_headers, began_at)
+    request = Rack::Request.new(env)
+
+    record = {
+      host: request.ip,
+      user: request.get_header("REMOTE_USER"),
+      method: request.request_method,
+      path: request.path_info,
+      protocol: request.get_header("HTTP_VERSION"),
+      query_string: (request.query_string.empty? ? nil : "?#{request.query_string}"),
+      status: status,
+      size: response_headers[CONTENT_LENGTH].to_i,
+      referer: request.referer,
+      user_agent: request.user_agent,
+      elapsed_time_in_seconds: (Rack::Utils.clock_time - began_at)
+    }
+
+    @logger << record
+  end
+end


### PR DESCRIPTION
This PR creates Rack Middleware for metrics and for structured access logs.

For metrics, the middleware works a lot like Prometheus::Middleware::Collector, but it looks for custom headers in the response for labels about requests. The Sinatra routes can add headers that the middleware can use. Before returning the response, the metrics headers are removed. 

For access logs, since we're using Sinatra::Base we lose the default common logs. With Loki it's a lot easier to work with stuctured logs, so this middleware rewrites `Rack::CommonLogger` to emit a `json` version of the access logs. It adds `referer` and `agent` and keeps the `elapsed_time_in_seconds`.