### PR TITLE
Updating full record page title.

### DIFF
--- a/lib/search/presenters.rb
+++ b/lib/search/presenters.rb
@@ -47,7 +47,7 @@ module Search::Presenters
     record = Record.for_datastore(datastore: slug, id: record_id)
 
     OpenStruct.new(
-      title: "#{record.title} - Record - #{datastore.title}",
+      title: "#{record.title[0].text} - Record - #{datastore.title}",
       current_datastore: slug,
       description: datastore.description,
       icons: Icons.new(record.icons + ["mail", "chat", "format_quote", "draft", "link", "collections_bookmark", "devices", "keyboard_arrow_right", "location_on", "check_circle", "warning", "error", "list", "arrow_back_ios", "arrow_forward_ios"]),


### PR DESCRIPTION
# Overview
The page title format for full records has been: `[datastore.title] - Library Search`.

This pull request updates it to match the format of current Search: `[record.title] - Record - [datastore.title] - Library Search`.