### PR TITLE
Sorting

### DIFF
--- a/lib/search/clients/catalog_api.rb
+++ b/lib/search/clients/catalog_api.rb
@@ -17,8 +17,8 @@ module Search
         @conn.get("records/#{id}").body
       end
 
-      def get_results(limit: 10, offset: 0, query: "*", filters: [], ht_search_only: false)
-        @conn.get("search", offset: offset, limit: limit, query: query, ht_search_only: ht_search_only, filters: filters).body
+      def get_results(limit: 10, offset: 0, query: "*", filters: [], ht_search_only: false, sort: "")
+        @conn.get("search", offset: offset, limit: limit, query: query, ht_search_only: ht_search_only, filters: filters, sort: sort).body
       end
     end
   end

--- a/lib/search/models/results/catalog.rb
+++ b/lib/search/models/results/catalog.rb
@@ -34,18 +34,18 @@ class Search::Models::Results::Catalog
   end
 
   def self.for(uri)
-    qh = uri.query_hash
-    current_page = (qh["page"] || 1).to_i
+    qh = uri.query_hash # duplicate values can be arrays
+    query_values = uri.query_values # flattens duplicate values
 
-    limit = (qh["limit"] || 10).to_i
+    current_page = (query_values["page"] || 1).to_i
 
-    qh["query"] || ""
+    limit = (query_values["limit"] || 10).to_i
     get_filters(qh)
 
     params = {
       offset: ((current_page - 1) * limit),
       limit: limit,
-      query: qh["query"] || "",
+      query: query_values["query"] || "",
       filters: get_filters(qh)
     }
 

--- a/lib/search/models/results/catalog.rb
+++ b/lib/search/models/results/catalog.rb
@@ -46,7 +46,8 @@ class Search::Models::Results::Catalog
       offset: ((current_page - 1) * limit),
       limit: limit,
       query: query_values["query"] || "",
-      filters: get_filters(qh)
+      filters: get_filters(qh),
+      sort: query_values["sort"] || "relevance"
     }
 
     params[:ht_search_only] = true if ht_search_only(qh)

--- a/lib/search/presenters/page/results.rb
+++ b/lib/search/presenters/page/results.rb
@@ -44,6 +44,10 @@ class Search::Presenters::Page
       @results.active_filters
     end
 
+    def sort_options
+      @results.sort_options
+    end
+
     def boolean_filters
       @results.boolean_filters
     end

--- a/lib/search/presenters/results.rb
+++ b/lib/search/presenters/results.rb
@@ -21,6 +21,17 @@ class Search::Presenters::Results::Catalog
     "region",
     "collection"
   ]
+
+  SORT_OPTIONS = [
+    {uid: "relevance", name: "Relevance"},
+    {uid: "date_asc", name: "Published/Created Date (oldest first)"},
+    {uid: "date_desc", name: "Published/Created Date (newest first)"},
+    {uid: "author_asc", name: "Author (A-Z)"},
+    {uid: "author_desc", name: "Author (Z-A)"},
+    {uid: "date_added", name: "Date added (Newest First)"},
+    {uid: "title_asc", name: "Title (A-Z)"},
+    {uid: "title_desc", name: "Title (Z-A)"}
+  ]
   def self.for(uri)
     results_model_instance = Search::Models::Results::Catalog.for(uri)
     new(results_model_instance)
@@ -65,9 +76,34 @@ class Search::Presenters::Results::Catalog
     @results.pagination
   end
 
+  def sort_options
+    SORT_OPTIONS.map do |option|
+      SortOption.new(**option, uri: @results.originating_uri)
+    end
+  end
+
   def records
     @results.records.map do |record|
       Search::Presenters::Record::Catalog::Brief.new(record)
+    end
+  end
+
+  class SortOption
+    attr_reader :uid, :name
+    def initialize(uid:, name:, uri:)
+      @uid = uid
+      @name = name
+      @uri = uri
+    end
+
+    def selected
+      # This will take the first of the sort matches
+      sort_value = (@uri.query_values || {})["sort"]
+      if (sort_value.nil? && uid == "relevance") || sort_value == uid
+        "selected"
+      else
+        ""
+      end
     end
   end
 end

--- a/spec/presenters/results/catalog_spec.rb
+++ b/spec/presenters/results/catalog_spec.rb
@@ -1,10 +1,25 @@
 describe Search::Presenters::Results::Catalog do
+  let(:api_results) { JSON.parse(fixture("results/catalog.json")) }
   context "#filters" do
     it "has the filters in the expected order" do
-      api_results = JSON.parse(fixture("results/catalog.json"))
-      results_model = Search::Models::Results::Catalog.new(data: api_results, originating_uri: S.base_url)
+      results_model = Search::Models::Results::Catalog.new(data: api_results, originating_uri: Addressable::URI.parse(S.base_url))
       subject = described_class.new(results_model)
       expect(subject.filters.first.name).to eq("Availability")
+    end
+  end
+  context "#sort_options" do
+    it "has a list of sort options starting with relevance" do
+      results_model = Search::Models::Results::Catalog.new(data: api_results, originating_uri: Addressable::URI.parse(S.base_url))
+      subject = described_class.new(results_model).sort_options.first
+      expect(subject.name).to eq("Relevance")
+      expect(subject.uid).to eq("relevance")
+      expect(subject.selected).to eq("selected")
+    end
+    it "has a selected sort option based on the sort query string" do
+      results_model = Search::Models::Results::Catalog.new(data: api_results, originating_uri: Addressable::URI.parse("#{S.base_url}/catalog?sort=title_asc"))
+      subject = described_class.new(results_model).sort_options
+      expect(subject.first.selected).to eq("")
+      expect(subject[6].selected).to eq("selected")
     end
   end
 end

--- a/spec/requests/requests_spec.rb
+++ b/spec/requests/requests_spec.rb
@@ -102,7 +102,7 @@ RSpec.describe "requests" do
   end
   context "catalog search results" do
     it "shows the results page when there is a query parameter" do
-      stub_request(:get, "#{S.catalog_api_url}/search?offset=0&query=title:(test)&limit=10&filters=library:aa&ht_search_only=false")
+      stub_request(:get, "#{S.catalog_api_url}/search?offset=0&query=title:(test)&limit=10&filters=library:aa&ht_search_only=false&sort=relevance")
         .to_return(status: 200, body: base_results.to_json, headers: {content_type: "application/json"})
       get "/catalog?query=title:(test)"
       expect(last_response.body).to include("Catalog results")

--- a/views/datastores/results/partials/summary/_sort.erb
+++ b/views/datastores/results/partials/summary/_sort.erb
@@ -1,14 +1,4 @@
 <%
-  sort_options = {
-    "relevance" => "Relevance",
-    "date_asc" => "Published/Created Date (oldest first)",
-    "date_desc" => "Published/Created Date (newest first)",
-    "author_asc" => "Author (A-Z)",
-    "author_desc" => "Author (Z-A)",
-    "date_added" => "Date added (Newest First)",
-    "title_asc" => "Title (A-Z)",
-    "title_desc" => "Title (Z-A)"
-  }
   uri = Addressable::URI.parse(request.fullpath)
   params_hash = uri.query_hash
 %>
@@ -27,8 +17,8 @@
   <% end %>
   <label for="sort__select" class="sort__label">Sort by</label>
   <select name="sort" class="sort__select" id="sort__select" autocomplete="off">
-    <% sort_options.each do |key, value| %>
-      <option value="<%= key %>" <%= "selected" if (params_hash["sort"]&.first == key) %>><%= value %></option>
+    <% @presenter.sort_options.each do |option| %>
+      <option value="<%= option.uid %>" <%= option.selected %>><%= option.name %></option>
     <% end %>
   </select>
   <button type="submit" class="sort__submit hide__javascript">Apply</button>


### PR DESCRIPTION
results presenter handles sorting options

for query values that should be a single string, we follow how `Addressable::URI.query_values` handles it. The last instance is the one that is picked. 