### PR TITLE
Move to namespaced api

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -91,7 +91,7 @@ services:
       - python
       - -m
       - uvicorn
-      - catalog_api.main:app
+      - api.main:app
       - --host
       - 0.0.0.0
   parser:

--- a/lib/search/clients/catalog_api.rb
+++ b/lib/search/clients/catalog_api.rb
@@ -13,12 +13,12 @@ module Search
         end
       end
 
-      def get_record(id)
-        @conn.get("records/#{id}").body
+      def get_catalog_record(id)
+        @conn.get("catalog/records/#{id}").body
       end
 
-      def get_results(limit: 10, offset: 0, query: "*", filters: [], ht_search_only: false, sort: "")
-        @conn.get("search", offset: offset, limit: limit, query: query, ht_search_only: ht_search_only, filters: filters, sort: sort).body
+      def get_catalog_results(limit: 10, offset: 0, query: "*", filters: [], ht_search_only: false, sort: "")
+        @conn.get("catalog/search", offset: offset, limit: limit, query: query, ht_search_only: ht_search_only, filters: filters, sort: sort).body
       end
     end
   end

--- a/lib/search/models/record/catalog.rb
+++ b/lib/search/models/record/catalog.rb
@@ -10,7 +10,7 @@ class Search::Models::Record::Catalog
     data = nil
     Yabeda.catalog_api_full_record_duration.measure do
       # get data from the api with the client
-      data = Search::Clients::CatalogAPI.new.get_record(id)
+      data = Search::Clients::CatalogAPI.new.get_catalog_record(id)
     end
     new(data)
   end

--- a/lib/search/models/results/catalog.rb
+++ b/lib/search/models/results/catalog.rb
@@ -52,7 +52,7 @@ class Search::Models::Results::Catalog
 
     params[:ht_search_only] = true if ht_search_only(qh)
 
-    data = Search::Clients::CatalogAPI.new.get_results(**params)
+    data = Search::Clients::CatalogAPI.new.get_catalog_results(**params)
     new(data: data, originating_uri: uri)
   end
 

--- a/spec/actions/email_spec.rb
+++ b/spec/actions/email_spec.rb
@@ -12,7 +12,7 @@ describe Search::Actions::Email::Worker::Record do
       catalog: [bib_id]
     }
 
-    stub_request(:get, "#{S.catalog_api_url}/records/#{bib_id}")
+    stub_request(:get, "#{S.catalog_api_url}/catalog/records/#{bib_id}")
       .to_return(status: 200, body: api_resp_body.to_json, headers: {content_type: "application/json"})
 
     described_class.new.perform("from@default.invalid", "to@default.invalid", data)
@@ -39,7 +39,7 @@ describe Search::Actions::Email::Worker::List do
       catalog: [bib_id]
     }
 
-    stub_request(:get, "#{S.catalog_api_url}/records/#{bib_id}")
+    stub_request(:get, "#{S.catalog_api_url}/catalog/records/#{bib_id}")
       .to_return(status: 200, body: api_resp_body.to_json, headers: {content_type: "application/json"})
 
     described_class.new.perform("from@default.invalid", "to@default.invalid", data)

--- a/spec/requests/requests_spec.rb
+++ b/spec/requests/requests_spec.rb
@@ -102,7 +102,7 @@ RSpec.describe "requests" do
   end
   context "catalog search results" do
     it "shows the results page when there is a query parameter" do
-      stub_request(:get, "#{S.catalog_api_url}/search?offset=0&query=title:(test)&limit=10&filters=library:aa&ht_search_only=false&sort=relevance")
+      stub_request(:get, "#{S.catalog_api_url}/catalog/search?offset=0&query=title:(test)&limit=10&filters=library:aa&ht_search_only=false&sort=relevance")
         .to_return(status: 200, body: base_results.to_json, headers: {content_type: "application/json"})
       get "/catalog?query=title:(test)"
       expect(last_response.body).to include("Catalog results")
@@ -170,7 +170,7 @@ RSpec.describe "requests" do
       bib_id = "9912345"
       data = base_api_record
       call_number = data["call_number"][0]["text"]
-      stub_request(:get, "#{S.catalog_api_url}/records/#{bib_id}")
+      stub_request(:get, "#{S.catalog_api_url}/catalog/records/#{bib_id}")
         .to_return(status: 200, body: data.to_json, headers: {content_type: "application/json"})
       stub_request(:get, "#{S.catalog_browse_url}/carousel?query=#{call_number}")
         .to_return(status: 200, body: [], headers: {})
@@ -217,7 +217,7 @@ RSpec.describe "requests" do
       data = base_api_record
       bib_id = data["id"]
       data["citation"] = citation["citation"]
-      stub_request(:get, "#{S.catalog_api_url}/records/#{bib_id}")
+      stub_request(:get, "#{S.catalog_api_url}/catalog/records/#{bib_id}")
         .to_return(status: 200, body: data.to_json, headers: {content_type: "application/json"})
       get "/catalog/record/#{bib_id}/ris"
       expect(last_response.headers["Content-Type"]).to eq("application/x-research-info-systems")
@@ -225,7 +225,7 @@ RSpec.describe "requests" do
     end
     it "redirects to past activity when there is network timeout" do
       bib_id = "9912345"
-      stub_request(:get, "#{S.catalog_api_url}/records/#{bib_id}")
+      stub_request(:get, "#{S.catalog_api_url}/catalog/records/#{bib_id}")
         .to_timeout
       get "/catalog/record/#{bib_id}/ris"
       expect(last_response.status).to eq(302)


### PR DESCRIPTION
The Catalog API is going to server results for more than just the `catalog` datastore. Because of this we're renaming the folder in the api itself from `catalog-api` to just `api`. 

Because it's serving more than just catalog results, the catalog results are going be namespaced with `/catalog`. This PR uses these new routes. 