### PR TITLE
fix spaces in search bug and add rubocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,4 @@
+require: standard
+
+inherit_gem:
+  standard: config/base.yml

--- a/app.rb
+++ b/app.rb
@@ -247,7 +247,7 @@ class Search::Application < Sinatra::Base
     if library
       q_params["library"] = library
     end
-    q_params["query"] = URI.encode_www_form_component(params[:search_text])
+    q_params["query"] = params[:search_text]
 
     if option != "keyword"
       # The query gets wrapped if the selected search option is not `keyword`


### PR DESCRIPTION
There was unnecessary extra encoding.  (Probably in an effort to sanitize the input? I dunno.) Removing it fixed the bug. 