### PR TITLE
Use multistage build for node assets

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ FROM ruby:4.0-slim AS base
 
 ARG UID=1000
 ARG GID=1000
-ARG NODE_MAJOR=20
+ARG NODE_MAJOR=lts
 
 
 RUN apt-get update -yqq && apt-get install -yqq --no-install-recommends \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,36 @@
 ################################################################################
+# Node Assets
+################################################################################
+FROM node:25.9.0@sha256:c69f4e0640e5b065f2694579793e4309f1e0e49868b0f2fea29c44d9c0dc2caf AS assets
+
+# Use non-root "app" user in directory /app
+ARG UID=1000
+ARG GID=1000
+
+RUN groupadd -g ${GID} -o app
+RUN useradd -m -d /app -u ${UID} -g ${GID} -o -s /bin/bash app
+
+USER app
+
+WORKDIR /app
+
+# Install packages
+COPY package.json package-lock.json ./
+RUN npm ci
+
+COPY eslint.config.js ./
+COPY ./assets ./assets
+COPY ./test ./test
+
+RUN npm run build
+
+################################################################################
 # BASE
 ################################################################################
 FROM ruby:4.0-slim AS base
 
 ARG UID=1000
 ARG GID=1000
-ARG NODE_MAJOR=20
-
 
 RUN apt-get update -yqq && apt-get install -yqq --no-install-recommends \
   build-essential \
@@ -17,13 +41,6 @@ RUN apt-get update -yqq && apt-get install -yqq --no-install-recommends \
   vim\
   git
 
-
-RUN mkdir -p /etc/apt/keyrings
-RUN curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
-RUN echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_${NODE_MAJOR}.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list
-RUN apt-get update -yqq && apt-get install -yqq --no-install-recommends nodejs
-
-RUN npm install -g npm
 
 RUN groupadd -g ${GID} -o app
 RUN useradd -m -d /app -u ${UID} -g ${GID} -o -s /bin/bash app
@@ -70,6 +87,5 @@ USER app
 
 RUN bundle install
 
-RUN npm ci
-RUN npm run build
-
+COPY --chown=${UID}:{GID} --from=assets /app/public/scripts /app/public/scripts
+COPY --chown=${UID}:{GID} --from=assets /app/public/styles /app/public/styles

--- a/compose.yml
+++ b/compose.yml
@@ -118,7 +118,7 @@ services:
   js:
     build:
       context: .
-      target: development
+      target: assets
       args:
         UID: ${UID:-1000}
         GID: ${GID:-1000}
@@ -133,7 +133,7 @@ services:
   css:
     build:
       context: .
-      target: development
+      target: assets
       args:
         UID: ${UID:-1000}
         GID: ${GID:-1000}

--- a/init.sh
+++ b/init.sh
@@ -17,7 +17,7 @@ echo "📦 Installing Gems"
 docker compose run --rm app bundle
 
 echo "📦 Installing Node modules"
-docker compose run --rm web npm install
+docker compose run --rm js npm install
 
 echo "📦 Building js and css"
-docker compose run --rm web npm run build
+docker compose run --rm js npm run build


### PR DESCRIPTION
# Overview
We want to have dependabot keep node up to date. The most straightforward way to do that is to separate out the building of js assets from the ruby app. That means the ruby image can't run node, but we don't need it to run the app.

The js/css docker compose services need to use the assets target instead of the main web target.