### PR TITLE
fixes specialist image permissions; changes name of rake task

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -3,6 +3,6 @@ Bundler.require(:default)
 Bundler.require(:metrics)
 require_relative "lib/search"
 desc "Download and update profile photos"
-task :get_profile_photos do
+task :update_profile_photos do
   Search::ProfilePhotos.update
 end

--- a/init.sh
+++ b/init.sh
@@ -28,10 +28,10 @@ docker compose run --rm js npm run build
 echo "📦 Installing Gems"
 docker compose run --rm app bundle
 
-staff_photos_count=`find public/images/specialists/. -maxdepth 1 -type f -name *.jpg | wc -l`
-if [ $staff_photos_count != 0 ]; then
-  echo "🖼️ staff photos already exist. Not rerunning"
+specialist_photos_count=`find public/images/specialists/. -maxdepth 1 -type f -name *.jpg | wc -l`
+if [ $specialist_photos_count != 0 ]; then
+  echo "🖼️ specialist photos already exist. Not rerunning"
 else
-  echo "🖼️ pulling staff photos"
-  docker compose run --rm app rake get_profile_photos
+  echo "🖼️ pulling specialist photos"
+  docker compose run --rm app rake update_profile_photos
 fi

--- a/lib/search/profile_photos.rb
+++ b/lib/search/profile_photos.rb
@@ -96,10 +96,12 @@ module Search::ProfilePhotos
       end
 
       image.format "jpeg"
-      image.write(File.join(@local_images_directory, jpg_filename))
+      image.write(local_jpg_path)
+      FileUtils.chmod("a+r", local_jpg_path)
 
       image.format "webp"
-      image.write(File.join(@local_images_directory, webp_filename))
+      image.write(local_webp_path)
+      FileUtils.chmod("a+r", local_webp_path)
     end
 
     private
@@ -114,6 +116,10 @@ module Search::ProfilePhotos
 
     def local_webp_path
       File.join(@local_images_directory, webp_filename)
+    end
+
+    def local_jpg_path
+      File.join(@local_images_directory, jpg_filename)
     end
 
     def remote_image_address


### PR DESCRIPTION
MiniMagick creates images with read/write user permissions only. This PR changes it to make the images readable by all. 

The PR also changes the name of the rake task to `update_profile_photos`. 