### PR TITLE
Fixing Firefox wrapping bug for specialists list.

### DIFF
--- a/assets/styles/datastores/results/partials/results-list/_specialists.scss
+++ b/assets/styles/datastores/results/partials/results-list/_specialists.scss
@@ -33,6 +33,7 @@ $class: '.specialists';
 // ******************** //
 
 #{$class} {
+  container-type: inline-size;
   text-align: center;
 }
 
@@ -66,9 +67,13 @@ $class: '.specialists';
 // *************** //
 
 #{$class}__list {
-  @include utilities.flex($align: start, $responsive: 'xl', $wrap: true);
   padding: 0 1rem;
   text-align: left;
+  @container (min-width: 45rem) {
+    display: grid;
+    gap: 0.5rem 1rem;
+    grid-template-columns: repeat(3, 1fr);
+  }
 }
 
 
@@ -82,12 +87,9 @@ $class: '.specialists';
   flex: 1 1 0;
   padding: 1rem 0;
   width: 100%;
-  @include media.breakpoint('xl') {
-    max-width: calc(33.333% - 2rem);
-  }
   & + #{$class}__list--item {
     border-top: 1px solid var(--search-color-grey-400);
-    @include media.breakpoint('xl') {
+    @container (min-width: 45rem) {
       border-top: none;
     }
   }


### PR DESCRIPTION
Firefox was not cooperating with `flex-wrap`. The list has been converted to a `grid` display, relying on the overwall width of its parent container.
<img width="890" height="430" alt="Screenshot 2026-05-29 at 10 28 07 AM" src="https://github.com/user-attachments/assets/128d8b52-ab69-4143-9e7d-d6795ab8f1f5" />
